### PR TITLE
Update deps to match enclave build requirements

### DIFF
--- a/iref/Cargo.toml
+++ b/iref/Cargo.toml
@@ -24,7 +24,7 @@ smallvec = "1.2"
 thiserror = { version = "1.0.40", optional = true }
 static-regular-grammar = { path = "../static-regular-grammar", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }
-hashbrown = { version = "0.14.0", optional = true }
+hashbrown = { version = "=0.14.3", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/json-ld/Cargo.toml
+++ b/json-ld/Cargo.toml
@@ -58,6 +58,7 @@ edition = "2021"
 version = "0.21.1"
 
 [workspace.dependencies]
+ahash = { version = "=0.8.6", default-features = false, features = ["no-rng"] }
 json-ld = { path = ".", version = "0.21.1", default-features = false }
 json-ld-syntax = { path = "crates/syntax", default-features = false, version = "0.21.1" }
 json-ld-core = { path = "crates/core", default-features = false, version = "0.21.1" }
@@ -73,7 +74,7 @@ locspan = { path = "../locspan", default-features = false }
 educe = { path = "../educe" }
 futures = { version = "0.3", default-features = false }
 mown = { path = "../mown", default-features = false }
-hashbrown = "0.12.1"
+hashbrown = "=0.14.3"
 smallvec = "1.10"
 log = "0.4.17"
 thiserror-nostd-notrait = { version = "1.0", default-features = false }

--- a/json-ld/crates/context-processing/Cargo.toml
+++ b/json-ld/crates/context-processing/Cargo.toml
@@ -24,6 +24,6 @@ futures.workspace = true
 mown.workspace = true
 contextual.workspace = true
 hashbrown.workspace = true
-ahash = { version = "=0.7.7", default-features = false }
+ahash.workspace = true
 thiserror-nostd-notrait.workspace = true
 async-recursion = "1.1.1"

--- a/json-ld/crates/core/Cargo.toml
+++ b/json-ld/crates/core/Cargo.toml
@@ -31,7 +31,7 @@ futures.workspace = true
 langtag.workspace = true
 smallvec.workspace = true
 hashbrown.workspace = true
-ahash = { version = "=0.7.7", default-features = false }
+ahash.workspace = true
 thiserror-nostd-notrait.workspace = true
 indexmap.workspace = true
 serde = { workspace = true, optional = true }

--- a/json-ld/crates/syntax/Cargo.toml
+++ b/json-ld/crates/syntax/Cargo.toml
@@ -23,7 +23,7 @@ rdf-types.workspace = true
 json-syntax.workspace = true
 locspan.workspace = true
 hashbrown.workspace = true
-ahash = { version = "=0.7.7", default-features = false }
+ahash.workspace = true
 educe.workspace = true
 smallvec.workspace = true
 contextual.workspace = true

--- a/json-syntax/Cargo.toml
+++ b/json-syntax/Cargo.toml
@@ -36,8 +36,8 @@ locspan = { path = "../locspan", default-features = false }
 locspan-derive = "0.6"
 indexmap = { version = "2.2", default-features = false }
 decoded-char = { path = "../decoded-char", default-features = false }
-hashbrown = { version = "0.12.1", features = [ "raw" ] }
-ahash = { version = "=0.7.7", default-features = false }
+hashbrown = { version = "=0.14.3", features = [ "raw" ] }
+ahash = { version = "=0.8.6", default-features = false }
 contextual = { path = "../contextual", default-features = false, optional = true }
 ryu-js = { version = "0.2.2", optional = true }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }

--- a/linked-data/Cargo.toml
+++ b/linked-data/Cargo.toml
@@ -27,7 +27,7 @@ xsd-types = { path = "../xsd-types", default-features = false }
 static-iref = { path = "../static-iref", default-features = false }
 json-syntax = { path = "../json-syntax", default-features = false, features = ["canonicalize"] }
 educe = { path = "../educe" }
-hashbrown = "0.12.1"
+hashbrown = "=0.14.3"
 iref.workspace = true
 thiserror-nostd-notrait.workspace = true
 linked-data-derive = { workspace = true, optional = true }

--- a/rdf-types/Cargo.toml
+++ b/rdf-types/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "0.8", optional = true }
 
 # Minor dependencies.
 indexmap = { version = "2.2", default-features = false }
-ahash = { version = "=0.7.7", default-features = false }
+ahash = { version = "=0.8.6", default-features = false }
 educe = "0.5.11"
 slab = { version = "0.4.8", default-features = false }
 replace_with = { version = "0.1.7", default-features = false }

--- a/ssi/Cargo.toml
+++ b/ssi/Cargo.toml
@@ -22,6 +22,7 @@ std = [ "ssi-rdf/std" ]
 ssi-rdf = { path = "./crates/rdf", version = "0.1", default-features = false }
 ssi-crypto = { path = "./crates/crypto", version = "0.1", default-features = false }
 
+ahash = { version = "=0.8.6", default-features = false }
 iref = { path = "../iref", default-features = false }
 rdf-types = { path = "../rdf-types", default-features = false }
 xsd-types = { path = "../xsd-types", default-features = false }

--- a/ssi/crates/rdf/Cargo.toml
+++ b/ssi/crates/rdf/Cargo.toml
@@ -19,7 +19,7 @@ rdf-types.workspace = true
 linked-data.workspace = true
 serde.workspace = true
 indexmap.workspace = true
-ahash = { version = "=0.7.7", default-features = false }
+ahash.workspace = true
 combination = { path = "../../../combination", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
In particular, hashbrown and ahash were causing some trouble.  But, their version requirements can be updated to work within an enclave build.

ahash's RandomState::default is disabled by default without access to getrandom, but 'no-rng' re-enables it.